### PR TITLE
adding QA agent exclusion

### DIFF
--- a/useragents.dat
+++ b/useragents.dat
@@ -44,5 +44,6 @@ exclude Twitterbot/.*
 exclude SocialRankIOBot; http://socialrank.io/about
 exclude CCBot/.* http://commoncrawl.org/about/
 exclude ltx71.*\(http://ltx71.com/\)
+exclude Zepheira QA/.*
 exclude canonical
 exclude embedded


### PR DESCRIPTION
I'm sporadically playing with automated QA stuff, and as it expands to verifying links, I realized it should be excluded from reports - so I've set the user agent for it to 'Zepheira QA/(chrome|node)' and added a rule to keep it out of view.