### PR TITLE
Add more exclusion rules

### DIFF
--- a/useragents.dat
+++ b/useragents.dat
@@ -25,7 +25,7 @@ exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) Appl
 #$ 50,000 hits/day
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
 ## Hiding behind an old user agent.
-eclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
+exclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
 
 #$ 25,000 hits/day
 ## This appears to be the most recent variant on their UA.

--- a/useragents.dat
+++ b/useragents.dat
@@ -68,8 +68,17 @@ exclude weborama-fetcher \(\+http://www\.weborama\.com\)
 exclude .* \(Applebot/.*; \+http://www\.apple\.com/go/applebot\)
 exclude serpstatbot/.*
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
-exclude .* UCBrowser/.*
+
+##### HTTP library
+exclude .* Daum/.*; \+http://cs\.daum\.net.*
+
+##### Chinese bots
 exclude .* LieBaoFast/.*
 exclude .* Mb2345Browser/.*
+
+##### These may need to be refined as they are clearly bots but hide behind valid Chinese software (WeChat, UCBrowser)
 exclude .* Mobile MQQBrowser/.* MicroMessenger/.*
-exclude .* Daum/.*; \+http://cs\.daum\.net.*
+exclude .* UCBrowser/.*
+
+##### This is likely a valid user agent but is being abused by a misbehaved bot, possibly a botnet based on IPs it uses
+exclude Mozilla/4\.0 \(compatible; MSIE 8\.0; Windows NT 5\.1; Trident/4\.0; \.NET CLR 2\.0\.50727\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -7,7 +7,7 @@
 
 #$ 100,000+ hits/day
 ##### Most used.
-exclude .* MJ12bot/.*; http://mj12bot.com/\)
+exclude .* MJ12bot/.*; http://mj12bot\.com/\)
 
 ##### Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
 exclude .*[Cc]rawler.*
@@ -24,9 +24,9 @@ exclude .* UCBrowser/.*
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
 
 #$ 25,000 hits/day
-exclude CCBot/.* \(https://commoncrawl.org/faq/\)
-exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\).*
-exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
+exclude CCBot/.* \(https://commoncrawl\.org/faq/\)
+exclude Mozilla/5\.0 \(compatible; YandexBot/.*; \+http://yandex\.com/bots\).*
+exclude PiplBot.*\(\+http://www\.pipl\.com/bot/\)
 
 #$ 10,000 hits/day
 exclude serpstatbot/.*
@@ -35,9 +35,9 @@ exclude serpstatbot/.*
 exclude .*[Ss]pider.*
 
 #$ 2,000 hits/day
-exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
-exclude .* DotBot/.*; http://www.opensiteexplorer.org/dotbot, help@moz.com\)
-exclude .* [Bb]ingbot/.*; \+http://www.bing.com/bingbot.html?\)
+exclude .* Googlebot/.*; \+http://www\.google\.com/bot.html\)
+exclude .* DotBot/.*; http://www\.opensiteexplorer\.org/dotbot, help@moz\.com\)
+exclude .* [Bb]ingbot/.*; \+http://www\.bing\.com/bingbot\.html?\)
 
 ##### This is likely a valid user agent but is being abused by a misbehaved bot, possibly a botnet based on IPs it uses
 exclude Mozilla/4\.0 \(compatible; MSIE 8\.0; Windows NT 5\.1; Trident/4\.0; \.NET CLR 2\.0\.50727\)
@@ -51,7 +51,7 @@ exclude .* Daum/.*; \+http://cs\.daum\.net.*
 #$ 500 hits/day
 exclude ia_archiver
 exclude python-requests/.*
-exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
+exclude .* Qwantify/.*; \+https://www\.qwant\.com/\)/.*
 exclude The Knowledge AI
 
 #$ 100 hits/day
@@ -60,25 +60,25 @@ exclude Python/.* aiohttp/.*
 #$ 10 hits/day
 exclude Twitterbot/.*
 exclude .* \(Applebot/.*; \+http://www\.apple\.com/go/applebot\)
-exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
+exclude .* Mail\.RU_Bot/.*; \+http://go\.mail\.ru/help/robots\)
 exclude weborama-fetcher \(\+http://www\.weborama\.com\)
 exclude Mozilla/5\.0 \(compatible; YandexAccessibilityBot/3\.0; \+http://yandex\.com/bots\)
-exclude facebookexternalhit/.* \(\+http://www.facebook.com/externalhit_uatext.php\)
-exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
+exclude facebookexternalhit/.* \(\+http://www\.facebook\.com/externalhit_uatext\.php\)
+exclude .* linkdexbot/.*; \+http://www\.linkdex\.com/bots/\)
 
 ##### No recent hits
 exclude Zepheira QA/.*
-exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
-exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
-exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
-exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
-exclude .* Exabot/.*; \+http://www.exabot.com/go/robot\)
+exclude DuckDuckBot/.*; \(\+http://duckduckgo\.com/duckduckbot\.html\)
+exclude Linguee Bot \(\+http://www\.linguee\.com/bot; bot@linguee\.com\)
+exclude Mozilla/5\.0 \(compatible; SEOkicks; \+https://www\.seokicks\.de/robot\.html\)
+exclude .* BLEXBot/.*; \+http://webmeup-crawler\.com/\)
+exclude .* Exabot/.*; \+http://www\.exabot\.com/go/robot\)
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
-exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
-exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
-exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
+exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove\.com
+exclude .* Yahoo! Slurp; http://help\.yahoo\.com/help/us/ysearch/slurp\)
+exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex\.com/bots\)
 exclude Apache-HttpClient/.* \(Java/.*\)
-exclude panscient.com
-exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
-exclude SocialRankIOBot; http://socialrank.io/about
-exclude ltx71.*\(http://ltx71.com/\)
+exclude panscient\.com
+exclude Slackbot-LinkExpanding .* \(\+https://api\.slack\.com/robots\)
+exclude SocialRankIOBot; http://socialrank\.io/about
+exclude ltx71.*\(http://ltx71\.com/\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -8,60 +8,50 @@
 exclude .*[Cc]rawler.*
 exclude .*[Ss]pider.*
 exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
-exclude YisouSpider
-exclude MauiBot \(crawler.feedback\+wc@gmail.com\)
 exclude CCBot/.* \(https://commoncrawl.org/faq/\)
-exclude CCBot/.* \(http://commoncrawl.org/faq/\)
+# no hits
 exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
-exclude Companybook-Crawler \(\+https://www.companybooknetworking.com/\)
+# no hits
 exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
-exclude GarlikCrawler/.* \(http://garlik.com/, crawler@garlik.com\)
-exclude .* AhrefsBot/.*; \+http://ahrefs.com/robot/\)
-exclude Mozilla/5.0 \(Macintosh; Intel Mac OS X.*\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Safari/.* \(Applebot/.*; \+http://www.apple.com/go/applebot
-exclude Mozilla/5.0 \(compatible; Daum/.*; \+http://cs.daum.net/faq/15/4118.html?faqId=28966\)
+# no hits
 exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
 exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\).*
 exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
+# no hits
 exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
-exclude .* Baiduspider/.*; \+http://www.baidu.com/search/spider.html\)
 exclude .* [Bb]ingbot/.*; \+http://www.bing.com/bingbot.html?\)
-exclude Mozilla/5.0 \(iPhone; CPU iPhone OS.* like Mac OS X\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Mobile/.* Safari/.* \(compatible; bingbot/.*; \+http://www.bing.com/bingbot.htm\)
 exclude .* DotBot/.*; http://www.opensiteexplorer.org/dotbot, help@moz.com\)
+# no hits
 exclude .* Exabot/.*; \+http://www.exabot.com/go/robot\)
 exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
+# no hits
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
 exclude .* MJ12bot/.*; http://mj12bot.com/\)
+# no hits
 exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
-exclude .* MegaIndex.ru/.*; \+http://megaindex.com/crawler\)
-exclude .* SemrushBot/.*\~bl; \+http://www.semrush.com/bot.html\)
+# no hits
 exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
+# no hits
 exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
+# no hits
 exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
 exclude Mozilla/5\.0 \(compatible; YandexAccessibilityBot/3\.0; \+http://yandex\.com/bots\)
-exclude Mozilla/5.0 \(compatible; SiteExplorer/.*; \+http://siteexplorer.info/Backlink-Checker-Spider/\)
+# no hits
 exclude Apache-HttpClient/.* \(Java/.*\)
 exclude Python/.* aiohttp/.*
 exclude python-requests/.*
+# no hits
 exclude panscient.com 
-exclude Sogou Orion spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou Pic Spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou head spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou web spider/.* \(\+http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou-Test-Spider/.* \(compatible; MSIE .*; Windows 98\)
-exclude TurnitinBot \(https://turnitin.com/robot/crawlerinfo.html\)
-exclude erdc-gsadev-crawler \(Enterprise; T4-CAJN8GR8VSNFA; christopher.a.boler@erdc.dren.mil\)
 exclude facebookexternalhit/.* \(\+http://www.facebook.com/externalhit_uatext.php\)
-exclude facebot
-exclude ia_archiver \(\+http://www.alexa.com/site/help/webmasters; crawler@alexa.com\)
+# no hits
 exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
 exclude Twitterbot/.*
+# no hits
 exclude SocialRankIOBot; http://socialrank.io/about
-exclude CCBot/.*http://commoncrawl.org/about/
+# no hits
 exclude ltx71.*\(http://ltx71.com/\)
 exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
 exclude Zepheira QA/.*
-exclude canonical
-exclude embedded
 exclude Blackboard Safeassign
 exclude ia_archiver
 exclude weborama-fetcher \(\+http://www\.weborama\.com\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -29,6 +29,8 @@ exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
 exclude CCBot/.* \(https://commoncrawl\.org/faq/\)
 exclude Mozilla/5\.0 \(compatible; YandexBot/.*; \+http://yandex\.com/bots\).*
 exclude PiplBot.*\(\+http://www\.pipl\.com/bot/\)
+## Bot(net?) hiding behind an old user agent; so far a one off, hit hard on one day
+exclude Mozilla/4\.0 \(compatible; MSIE 6\.0; Windows NT 5\.1; SV1\)
 
 #$ 10,000 hits/day
 exclude serpstatbot/.*

--- a/useragents.dat
+++ b/useragents.dat
@@ -61,6 +61,7 @@ exclude The Knowledge AI
 
 #$ 100 hits/day
 exclude Python/.* aiohttp/.*
+exclude Linguee Bot \(http://www\.linguee\.com/bot; bot@linguee\.com\)
 
 #$ 10 hits/day
 exclude Twitterbot/.*
@@ -76,7 +77,6 @@ exclude .* linkdexbot/.*; \+http://www\.linkdex\.com/bots/\)
 ## ...
 exclude Zepheira QA/.*
 exclude DuckDuckBot/.*; \(\+http://duckduckgo\.com/duckduckbot\.html\)
-exclude Linguee Bot \(\+http://www\.linguee\.com/bot; bot@linguee\.com\)
 exclude Mozilla/5\.0 \(compatible; SEOkicks; \+https://www\.seokicks\.de/robot\.html\)
 exclude .* BLEXBot/.*; \+http://webmeup-crawler\.com/\)
 exclude .* Exabot/.*; \+http://www\.exabot\.com/go/robot\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -3,7 +3,7 @@
 # Lines starting with # (optionally after whitespace) are ignored. Blank lines are ignored.
 # Include by default.  Only include if a more generic exclude would have excluded it and a more specific include adds it back.
 # Example: 
-# include Mozilla/5.0 (Windows NT .*) AppleWebKit/[\d\.]* (KHTML, like Gecko) Chrome/[\d\.]* Safari/[\d\.]*
+# include Mozilla/5\.0 \(Windows NT .*\) AppleWebKit/[\d\.]* \(KHTML, like Gecko\) Chrome/[\d\.]* Safari/[\d\.]*
 # exclude AhrefsBot/.*
 
 #$ over 100,000 hits/day
@@ -18,7 +18,7 @@ exclude .*[Cc]rawler.*
 exclude .* LieBaoFast/.*
 exclude .* Mb2345Browser/.*
 ## These hide behind valid Chinese software (WeChat, UCBrowser), so block the specific UA for now
-exclude Mozilla/5\.0 \(Linux; Android 7\.0; FRD-AL00 Build/HUAWEIFRD-AL00; wv\) AppleWebKit/537\.36 (KHTML, like Gecko) Version/4\.0 Chrome/53\.0\.2785\.49 Mobile MQQBrowser/6\.2 TBS/043602 Safari/537\.36 MicroMessenger/6\.5\.16\.1120 NetType/WIFI Language/zh_CN
+exclude Mozilla/5\.0 \(Linux; Android 7\.0; FRD-AL00 Build/HUAWEIFRD-AL00; wv\) AppleWebKit/537\.36 \(KHTML, like Gecko\) Version/4\.0 Chrome/53\.0\.2785\.49 Mobile MQQBrowser/6\.2 TBS/043602 Safari/537\.36 MicroMessenger/6\.5\.16\.1120 NetType/WIFI Language/zh_CN
 exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) AppleWebKit/537\.36\(KHTML,like Gecko\) Version/4\.0 Chrome/40\.0\.2214\.89 UCBrowser/11\.7\.0\.953 Mobile Safari/537\.36
 
 #$ 50,000 hits/day

--- a/useragents.dat
+++ b/useragents.dat
@@ -24,9 +24,8 @@ exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) Appl
 
 #$ 50,000 hits/day
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
-## Appears to be a distributed crawler using a limited variety of old user agents. 
-exclude Mozilla/5\.0 \(Macintosh; Intel Mac OS X 10\.(6|7|8|9|10); rv:(37|38|43|68)\.0\) Gecko/20100101 Firefox/(37|38|43|68)\.0 
-exclude Mozilla/5\.0 \(Windows NT (6\.1|6\.2|6\.3|10\.0); (WOW64; |Win64; x64; |)rv:(37|38|43|68)\.0\) Gecko/20100101 Firefox/(37|38|43|68)\.0 
+## Hiding behind an old user agent, may be early .xyz spam.
+eclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
 
 #$ 25,000 hits/day
 ## This appears to be the most recent variant on their UA.

--- a/useragents.dat
+++ b/useragents.dat
@@ -40,7 +40,7 @@ exclude serpstatbot/.*
 ## Generic rule for anything identifying itself as a spider.  Avoid adding anything else that matches this.
 exclude .*[Ss]pider.*
 ## The Splash scraper: https://github.com/scrapinghub/splash - fakes UAs but with its own signature
-exclue .* splash Version/.* .*
+exclude .* splash Version/.* .*
 
 #$ 2,000 hits/day
 exclude .* Googlebot/.*; \+http://www\.google\.com/bot.html\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -24,8 +24,9 @@ exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) Appl
 
 #$ 50,000 hits/day
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
-## Hiding behind an old user agent, may be early .xyz spam.
-eclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
+## Distributed crawler hiding behind a randomized combination of old user agent pieces.
+exclude Mozilla/5\.0 \(Macintosh; Intel Mac OS X 10\.(6|7|8|9|10); rv:(37|38|43|68)\.0\) Gecko/20100101 Firefox/(37|38|43|68)\.0 
+exclude Mozilla/5\.0 \(Windows NT (6\.1|6\.2|6\.3|10\.0); (WOW64; |Win64; x64; |)rv:(37|38|43|68)\.0\) Gecko/20100101 Firefox/(37|38|43|68)\.0 
 
 #$ 25,000 hits/day
 ## This appears to be the most recent variant on their UA.

--- a/useragents.dat
+++ b/useragents.dat
@@ -1,29 +1,31 @@
 # First word in line must be include or exclude. Remainder of line, after whitespace is a Python/Perl regex
 # Regex must match the entire user agents string.
 # Lines starting with # (optionally after whitespace) are ignored. Blank lines are ignored.
+# Include by default.  Only include if a more generic exclude would have excluded it and a more specific include adds it back.
 # Example: 
 # include Mozilla/5.0 (Windows NT .*) AppleWebKit/[\d\.]* (KHTML, like Gecko) Chrome/[\d\.]* Safari/[\d\.]*
 # exclude AhrefsBot/.*
 
-#$ 100,000+ hits/day
-##### Most used.
+#$ over 100,000 hits/day
+## Most hits.
 exclude .* MJ12bot/.*; http://mj12bot\.com/\)
 
-##### Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
+## Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
 exclude .*[Cc]rawler.*
 
 #$ 100,000 hits/day
-##### Chinese bots.  The next four appear to work in concert.
+## Chinese bots.  The next four appear to work in concert.
 exclude .* LieBaoFast/.*
 exclude .* Mb2345Browser/.*
-##### These may need to be refined as they are clearly bots but hide behind valid Chinese software (WeChat, UCBrowser)
-exclude .* Mobile MQQBrowser/.* MicroMessenger/.*
-exclude .* UCBrowser/.*
+## These hide behind valid Chinese software (WeChat, UCBrowser), so block the specific UA for now
+exclude Mozilla/5\.0 \(Linux; Android 7\.0; FRD-AL00 Build/HUAWEIFRD-AL00; wv\) AppleWebKit/537\.36 (KHTML, like Gecko) Version/4\.0 Chrome/53\.0\.2785\.49 Mobile MQQBrowser/6\.2 TBS/043602 Safari/537\.36 MicroMessenger/6\.5\.16\.1120 NetType/WIFI Language/zh_CN
+exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) AppleWebKit/537\.36\(KHTML,like Gecko\) Version/4\.0 Chrome/40\.0\.2214\.89 UCBrowser/11\.7\.0\.953 Mobile Safari/537\.36
 
 #$ 50,000 hits/day
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
 
 #$ 25,000 hits/day
+## This appears to be the most recent variant on their UA.
 exclude CCBot/.* \(https://commoncrawl\.org/faq/\)
 exclude Mozilla/5\.0 \(compatible; YandexBot/.*; \+http://yandex\.com/bots\).*
 exclude PiplBot.*\(\+http://www\.pipl\.com/bot/\)
@@ -31,7 +33,7 @@ exclude PiplBot.*\(\+http://www\.pipl\.com/bot/\)
 #$ 10,000 hits/day
 exclude serpstatbot/.*
 
-##### Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
+## Generic rule for anything identifying itself as a spider.  Avoid adding anything else that matches this.
 exclude .*[Ss]pider.*
 
 #$ 2,000 hits/day
@@ -39,19 +41,20 @@ exclude .* Googlebot/.*; \+http://www\.google\.com/bot.html\)
 exclude .* DotBot/.*; http://www\.opensiteexplorer\.org/dotbot, help@moz\.com\)
 exclude .* [Bb]ingbot/.*; \+http://www\.bing\.com/bingbot\.html?\)
 
-##### This is likely a valid user agent but is being abused by a misbehaved bot, possibly a botnet based on IPs it uses
+## This is likely a valid user agent but is being abused by a misbehaved bot, possibly a botnet based on IPs it uses
 exclude Mozilla/4\.0 \(compatible; MSIE 8\.0; Windows NT 5\.1; Trident/4\.0; \.NET CLR 2\.0\.50727\)
 
 #$ 1,000 hits/day
+## Yes, this is the entire UA.
 exclude Blackboard Safeassign
-
-##### HTTP library
 exclude .* Daum/.*; \+http://cs\.daum\.net.*
 
 #$ 500 hits/day
+## Yes, this is the entire UA.
 exclude ia_archiver
 exclude python-requests/.*
 exclude .* Qwantify/.*; \+https://www\.qwant\.com/\)/.*
+## Yes, this is the entire UA.
 exclude The Knowledge AI
 
 #$ 100 hits/day
@@ -67,6 +70,8 @@ exclude facebookexternalhit/.* \(\+http://www\.facebook\.com/externalhit_uatext\
 exclude .* linkdexbot/.*; \+http://www\.linkdex\.com/bots/\)
 
 ##### No recent hits
+
+## ...
 exclude Zepheira QA/.*
 exclude DuckDuckBot/.*; \(\+http://duckduckgo\.com/duckduckbot\.html\)
 exclude Linguee Bot \(\+http://www\.linguee\.com/bot; bot@linguee\.com\)
@@ -76,8 +81,10 @@ exclude .* Exabot/.*; \+http://www\.exabot\.com/go/robot\)
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
 exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove\.com
 exclude .* Yahoo! Slurp; http://help\.yahoo\.com/help/us/ysearch/slurp\)
+## May have been superceded by the accessibility version.
 exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex\.com/bots\)
 exclude Apache-HttpClient/.* \(Java/.*\)
+## Yes, this is the entire UA.
 exclude panscient\.com
 exclude Slackbot-LinkExpanding .* \(\+https://api\.slack\.com/robots\)
 exclude SocialRankIOBot; http://socialrank\.io/about

--- a/useragents.dat
+++ b/useragents.dat
@@ -58,10 +58,13 @@ exclude python-requests/.*
 exclude .* Qwantify/.*; \+https://www\.qwant\.com/\)/.*
 ## Yes, this is the entire UA.
 exclude The Knowledge AI
+## Someone working from the command line.
+exclude .* HeadlessChrome/.*
 
 #$ 100 hits/day
 exclude Python/.* aiohttp/.*
 exclude Linguee Bot \(http://www\.linguee\.com/bot; bot@linguee\.com\)
+exclude eContext/1\.0 \(eContext Classification Engine\)
 
 #$ 10 hits/day
 exclude Twitterbot/.*

--- a/useragents.dat
+++ b/useragents.dat
@@ -24,11 +24,9 @@ exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) Appl
 
 #$ 50,000 hits/day
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
-## Hiding behind an old user agent.
-exclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
 ## Appears to be a distributed crawler using a limited variety of old user agents. 
-exclude Mozilla/5\.0 \(Macintosh; Intel Mac OS X 10\.(6|7|8|9|10); rv:3[78]\.0\) Gecko/20100101 Firefox/3[78]\.0 
-exclude Mozilla/5\.0 \(Windows NT (6\.1|6\.2|6\.3|10\.0); (WOW64|Win64; x64); rv:3[78]\.0\) Gecko/20100101 Firefox/3[78]\.0 
+exclude Mozilla/5\.0 \(Macintosh; Intel Mac OS X 10\.(6|7|8|9|10); rv:(37|38|43|68)\.0\) Gecko/20100101 Firefox/(37|38|43|68)\.0 
+exclude Mozilla/5\.0 \(Windows NT (6\.1|6\.2|6\.3|10\.0); (WOW64; |Win64; x64; |)rv:(37|38|43|68)\.0\) Gecko/20100101 Firefox/(37|38|43|68)\.0 
 
 #$ 25,000 hits/day
 ## This appears to be the most recent variant on their UA.
@@ -71,7 +69,7 @@ exclude .* HeadlessChrome/.*
 exclude Python/.* aiohttp/.*
 exclude Linguee Bot \(http://www\.linguee\.com/bot; bot@linguee\.com\)
 exclude eContext/1\.0 \(eContext Classification Engine\)
-# Super old Ubuntu visits hundreds of times per day? Doubtful.
+## Super old Ubuntu visits hundreds of times per day? Doubtful.
 exclude Mozilla/5\.0 \(X11; U; Linux i686; en-GB; rv:1\.8\.1\.10\) Gecko/20071126 Ubuntu/7\.10 \(gutsy\) Firefox/2\.0\.0\.10
 
 #$ 10 hits/day

--- a/useragents.dat
+++ b/useragents.dat
@@ -9,47 +9,17 @@ exclude .*[Cc]rawler.*
 exclude .*[Ss]pider.*
 exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
 exclude CCBot/.* \(https://commoncrawl.org/faq/\)
-# no hits
-exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
-# no hits
-exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
-# no hits
-exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
 exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\).*
 exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
-# no hits
-exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
 exclude .* [Bb]ingbot/.*; \+http://www.bing.com/bingbot.html?\)
 exclude .* DotBot/.*; http://www.opensiteexplorer.org/dotbot, help@moz.com\)
-# no hits
-exclude .* Exabot/.*; \+http://www.exabot.com/go/robot\)
 exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
-# no hits
-exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
 exclude .* MJ12bot/.*; http://mj12bot.com/\)
-# no hits
-exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
-# no hits
-exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
-# no hits
-exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
-# no hits
-exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
 exclude Mozilla/5\.0 \(compatible; YandexAccessibilityBot/3\.0; \+http://yandex\.com/bots\)
-# no hits
-exclude Apache-HttpClient/.* \(Java/.*\)
 exclude Python/.* aiohttp/.*
 exclude python-requests/.*
-# no hits
-exclude panscient.com 
 exclude facebookexternalhit/.* \(\+http://www.facebook.com/externalhit_uatext.php\)
-# no hits
-exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
 exclude Twitterbot/.*
-# no hits
-exclude SocialRankIOBot; http://socialrank.io/about
-# no hits
-exclude ltx71.*\(http://ltx71.com/\)
 exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
 exclude Zepheira QA/.*
 exclude Blackboard Safeassign
@@ -72,3 +42,20 @@ exclude .* UCBrowser/.*
 
 ##### This is likely a valid user agent but is being abused by a misbehaved bot, possibly a botnet based on IPs it uses
 exclude Mozilla/4\.0 \(compatible; MSIE 8\.0; Windows NT 5\.1; Trident/4\.0; \.NET CLR 2\.0\.50727\)
+
+##### No recent hits
+exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
+exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
+exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
+exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
+exclude .* Exabot/.*; \+http://www.exabot.com/go/robot\)
+exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
+exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
+exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
+exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
+exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
+exclude Apache-HttpClient/.* \(Java/.*\)
+exclude panscient.com
+exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
+exclude SocialRankIOBot; http://socialrank.io/about
+exclude ltx71.*\(http://ltx71.com/\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -5,54 +5,77 @@
 # include Mozilla/5.0 (Windows NT .*) AppleWebKit/[\d\.]* (KHTML, like Gecko) Chrome/[\d\.]* Safari/[\d\.]*
 # exclude AhrefsBot/.*
 
-exclude .*[Cc]rawler.*
-exclude .*[Ss]pider.*
-exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
-exclude CCBot/.* \(https://commoncrawl.org/faq/\)
-exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\).*
-exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
-exclude .* [Bb]ingbot/.*; \+http://www.bing.com/bingbot.html?\)
-exclude .* DotBot/.*; http://www.opensiteexplorer.org/dotbot, help@moz.com\)
-exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
+#$ 100,000+ hits/day
+##### Most used.
 exclude .* MJ12bot/.*; http://mj12bot.com/\)
-exclude Mozilla/5\.0 \(compatible; YandexAccessibilityBot/3\.0; \+http://yandex\.com/bots\)
-exclude Python/.* aiohttp/.*
-exclude python-requests/.*
-exclude facebookexternalhit/.* \(\+http://www.facebook.com/externalhit_uatext.php\)
-exclude Twitterbot/.*
-exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
-exclude Zepheira QA/.*
-exclude Blackboard Safeassign
-exclude ia_archiver
-exclude weborama-fetcher \(\+http://www\.weborama\.com\)
-exclude .* \(Applebot/.*; \+http://www\.apple\.com/go/applebot\)
-exclude serpstatbot/.*
-exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
 
-##### HTTP library
-exclude .* Daum/.*; \+http://cs\.daum\.net.*
+##### Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
+exclude .*[Cc]rawler.*
 
-##### Chinese bots
+#$ 100,000 hits/day
+##### Chinese bots.  The next four appear to work in concert.
 exclude .* LieBaoFast/.*
 exclude .* Mb2345Browser/.*
-
 ##### These may need to be refined as they are clearly bots but hide behind valid Chinese software (WeChat, UCBrowser)
 exclude .* Mobile MQQBrowser/.* MicroMessenger/.*
 exclude .* UCBrowser/.*
 
+#$ 50,000 hits/day
+exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
+
+#$ 25,000 hits/day
+exclude CCBot/.* \(https://commoncrawl.org/faq/\)
+exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\).*
+exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
+
+#$ 10,000 hits/day
+exclude serpstatbot/.*
+
+##### Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
+exclude .*[Ss]pider.*
+
+#$ 2,000 hits/day
+exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
+exclude .* DotBot/.*; http://www.opensiteexplorer.org/dotbot, help@moz.com\)
+exclude .* [Bb]ingbot/.*; \+http://www.bing.com/bingbot.html?\)
+
 ##### This is likely a valid user agent but is being abused by a misbehaved bot, possibly a botnet based on IPs it uses
 exclude Mozilla/4\.0 \(compatible; MSIE 8\.0; Windows NT 5\.1; Trident/4\.0; \.NET CLR 2\.0\.50727\)
 
-##### No recent hits
+#$ 1,000 hits/day
+exclude Blackboard Safeassign
+
+##### HTTP library
+exclude .* Daum/.*; \+http://cs\.daum\.net.*
+
+#$ 500 hits/day
+exclude ia_archiver
+exclude python-requests/.*
 exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
+exclude The Knowledge AI
+
+#$ 100 hits/day
+exclude Python/.* aiohttp/.*
+
+#$ 10 hits/day
+exclude Twitterbot/.*
+exclude .* \(Applebot/.*; \+http://www\.apple\.com/go/applebot\)
+exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
+exclude weborama-fetcher \(\+http://www\.weborama\.com\)
+exclude Mozilla/5\.0 \(compatible; YandexAccessibilityBot/3\.0; \+http://yandex\.com/bots\)
+exclude facebookexternalhit/.* \(\+http://www.facebook.com/externalhit_uatext.php\)
+exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
+
+##### No recent hits
+exclude Zepheira QA/.*
 exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
+exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
 exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
 exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
 exclude .* Exabot/.*; \+http://www.exabot.com/go/robot\)
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
 exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
 exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
-exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
 exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
 exclude Apache-HttpClient/.* \(Java/.*\)
 exclude panscient.com

--- a/useragents.dat
+++ b/useragents.dat
@@ -20,7 +20,7 @@ exclude .* AhrefsBot/.*; \+http://ahrefs.com/robot/\)
 exclude Mozilla/5.0 \(Macintosh; Intel Mac OS X.*\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Safari/.* \(Applebot/.*; \+http://www.apple.com/go/applebot
 exclude Mozilla/5.0 \(compatible; Daum/.*; \+http://cs.daum.net/faq/15/4118.html?faqId=28966\)
 exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
-exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\)
+exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\).*
 exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
 exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
 exclude .* Baiduspider/.*; \+http://www.baidu.com/search/spider.html\)
@@ -37,9 +37,11 @@ exclude .* SemrushBot/.*\~bl; \+http://www.semrush.com/bot.html\)
 exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
 exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
 exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
+exclude Mozilla/5\.0 \(compatible; YandexAccessibilityBot/3\.0; \+http://yandex\.com/bots\)
 exclude Mozilla/5.0 \(compatible; SiteExplorer/.*; \+http://siteexplorer.info/Backlink-Checker-Spider/\)
 exclude Apache-HttpClient/.* \(Java/.*\)
 exclude Python/.* aiohttp/.*
+exclude python-requests/.*
 exclude panscient.com 
 exclude Sogou Orion spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
 exclude Sogou Pic Spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
@@ -62,3 +64,12 @@ exclude canonical
 exclude embedded
 exclude Blackboard Safeassign
 exclude ia_archiver
+exclude weborama-fetcher \(\+http://www\.weborama\.com\)
+exclude .* \(Applebot/.*; \+http://www\.apple\.com/go/applebot\)
+exclude serpstatbot/.*
+exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
+exclude .* UCBrowser/.*
+exclude .* LieBaoFast/.*
+exclude .* Mb2345Browser/.*
+exclude .* Mobile MQQBrowser/.* MicroMessenger/.*
+

--- a/useragents.dat
+++ b/useragents.dat
@@ -72,4 +72,4 @@ exclude .* UCBrowser/.*
 exclude .* LieBaoFast/.*
 exclude .* Mb2345Browser/.*
 exclude .* Mobile MQQBrowser/.* MicroMessenger/.*
-
+exclude .* Daum/.*; \+http://cs\.daum\.net.*

--- a/useragents.dat
+++ b/useragents.dat
@@ -9,10 +9,9 @@
 #$ over 100,000 hits/day
 ## Most hits.
 exclude .* MJ12bot/.*; http://mj12bot\.com/\)
-exclude Mozilla/5\.0 \(compatible; SEOkicks; \+https://www\.seokicks\.de/robot\.html\)
-
-## Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
+# Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
 exclude .*[Cc]rawler.*
+exclude Mozilla/5\.0 \(compatible; SEOkicks; \+https://www\.seokicks\.de/robot\.html\)
 
 #$ 100,000 hits/day
 ## Chinese bots.  The next four appear to work in concert.
@@ -38,9 +37,10 @@ exclude Mozilla/4\.0 \(compatible; MSIE 6\.0; Windows NT 5\.1; SV1\)
 
 #$ 10,000 hits/day
 exclude serpstatbot/.*
-
 ## Generic rule for anything identifying itself as a spider.  Avoid adding anything else that matches this.
 exclude .*[Ss]pider.*
+## The Splash scraper: https://github.com/scrapinghub/splash - fakes UAs but with its own signature
+exclue .* splash Version/.* .*
 
 #$ 2,000 hits/day
 exclude .* Googlebot/.*; \+http://www\.google\.com/bot.html\)

--- a/useragents.dat
+++ b/useragents.dat
@@ -26,6 +26,9 @@ exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) Appl
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
 ## Hiding behind an old user agent.
 exclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
+## Appears to be a distributed crawler using a limited variety of old user agents. 
+exclude Mozilla/5\.0 \(Macintosh; Intel Mac OS X 10\.(6|7|8|9|10); rv:3[78]\.0\) Gecko/20100101 Firefox/3[78]\.0 
+exclude Mozilla/5\.0 \(Windows NT (6\.1|6\.2|6\.3|10\.0); (WOW64|Win64; x64); rv:3[78]\.0\) Gecko/20100101 Firefox/3[78]\.0 
 
 #$ 25,000 hits/day
 ## This appears to be the most recent variant on their UA.
@@ -68,6 +71,8 @@ exclude .* HeadlessChrome/.*
 exclude Python/.* aiohttp/.*
 exclude Linguee Bot \(http://www\.linguee\.com/bot; bot@linguee\.com\)
 exclude eContext/1\.0 \(eContext Classification Engine\)
+# Super old Ubuntu visits hundreds of times per day? Doubtful.
+exclude Mozilla/5\.0 \(X11; U; Linux i686; en-GB; rv:1\.8\.1\.10\) Gecko/20071126 Ubuntu/7\.10 \(gutsy\) Firefox/2\.0\.0\.10
 
 #$ 10 hits/day
 exclude Twitterbot/.*

--- a/useragents.dat
+++ b/useragents.dat
@@ -9,6 +9,7 @@
 #$ over 100,000 hits/day
 ## Most hits.
 exclude .* MJ12bot/.*; http://mj12bot\.com/\)
+exclude Mozilla/5\.0 \(compatible; SEOkicks; \+https://www\.seokicks\.de/robot\.html\)
 
 ## Generic rule for anything identifying itself as a crawler.  Avoid adding anything else that matches this.
 exclude .*[Cc]rawler.*
@@ -23,6 +24,8 @@ exclude Mozilla/5\.0\(Linux;U;Android 5\.1\.1;zh-CN;OPPO A33 Build/LMY47V\) Appl
 
 #$ 50,000 hits/day
 exclude .* \(Amazonbot/.*; \+https://developer\.amazon\.com/support/amazonbot\)
+## Hiding behind an old user agent.
+eclude Mozilla/5\.0 \(Windows NT 10\.0; rv:68\.0\) Gecko/20100101 Firefox/68\.0
 
 #$ 25,000 hits/day
 ## This appears to be the most recent variant on their UA.
@@ -80,7 +83,6 @@ exclude .* linkdexbot/.*; \+http://www\.linkdex\.com/bots/\)
 ## ...
 exclude Zepheira QA/.*
 exclude DuckDuckBot/.*; \(\+http://duckduckgo\.com/duckduckbot\.html\)
-exclude Mozilla/5\.0 \(compatible; SEOkicks; \+https://www\.seokicks\.de/robot\.html\)
 exclude .* BLEXBot/.*; \+http://webmeup-crawler\.com/\)
 exclude .* Exabot/.*; \+http://www\.exabot\.com/go/robot\)
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)


### PR DESCRIPTION
Work in progress.  I've extracted these from recent channel log analysis but need to test them against the data to make sure they're not filtering out valid results.  The most difficult ones are the bottom four, which seem to be out of China and attempting to disguise themselves as mobile browsers.