### PR TITLE
Commenting out unclear lines

### DIFF
--- a/useragents.dat
+++ b/useragents.dat
@@ -10,9 +10,10 @@ exclude .*[Ss]pider.*
 exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
 ## should be blocked by the generic spider rule
 # exclude YisouSpider
-exclude MauiBot \(crawler.feedback\+wc@gmail.com\)
-## out of date, see below
-# exclude CCBot/.* \(https://commoncrawl.org/faq/\)
+## blocked
+# exclude MauiBot \(crawler.feedback\+wc@gmail.com\)
+exclude CCBot/.* \(https://commoncrawl.org/faq/\)
+## out of date
 # exclude CCBot/.* \(http://commoncrawl.org/faq/\)
 exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
 ## should be blocked by generic crawler rule
@@ -20,10 +21,12 @@ exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
 exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
 ## should be blocked by generic crawler rule
 # exclude GarlikCrawler/.* \(http://garlik.com/, crawler@garlik.com\)
-exclude .* AhrefsBot/.*; \+http://ahrefs.com/robot/\)
+## blocked
+# exclude .* AhrefsBot/.*; \+http://ahrefs.com/robot/\)
 ## this didn't work to block the apple bot, potentially added correctly in a different PR - missing end paren
 # exclude Mozilla/5.0 \(Macintosh; Intel Mac OS X.*\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Safari/.* \(Applebot/.*; \+http://www.apple.com/go/applebot
-exclude Mozilla/5.0 \(compatible; Daum/.*; \+http://cs.daum.net/faq/15/4118.html?faqId=28966\)
+## this didn't work to block the daum library
+# exclude Mozilla/5.0 \(compatible; Daum/.*; \+http://cs.daum.net/faq/15/4118.html?faqId=28966\)
 exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
 ## this didn't work to block the Yandex bot, potentially fixed in a different PR - account for suffixes
 # exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\)
@@ -39,9 +42,10 @@ exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
 exclude .* MJ12bot/.*; http://mj12bot.com/\)
 exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
-## should be covered by generic crawler rule
+## should be covered by generic crawler rule, also blocked
 # exclude .* MegaIndex.ru/.*; \+http://megaindex.com/crawler\)
-exclude .* SemrushBot/.*\~bl; \+http://www.semrush.com/bot.html\)
+## blocked
+# exclude .* SemrushBot/.*\~bl; \+http://www.semrush.com/bot.html\)
 exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
 exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
 exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
@@ -70,7 +74,8 @@ exclude ia_archiver
 exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
 exclude Twitterbot/.*
 exclude SocialRankIOBot; http://socialrank.io/about
-exclude CCBot/.*http://commoncrawl.org/about/
+## out of date, already described above
+# exclude CCBot/.*http://commoncrawl.org/about/
 exclude ltx71.*\(http://ltx71.com/\)
 exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
 exclude Zepheira QA/.*

--- a/useragents.dat
+++ b/useragents.dat
@@ -8,57 +8,74 @@
 exclude .*[Cc]rawler.*
 exclude .*[Ss]pider.*
 exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
-exclude YisouSpider
+## should be blocked by the generic spider rule
+# exclude YisouSpider
 exclude MauiBot \(crawler.feedback\+wc@gmail.com\)
-exclude CCBot/.* \(https://commoncrawl.org/faq/\)
-exclude CCBot/.* \(http://commoncrawl.org/faq/\)
+exclude CCBot/.* \(https?://commoncrawl.org/faq/\)
+## regex above now covers both of these cases
+# exclude CCBot/.* \(http://commoncrawl.org/faq/\)
 exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
-exclude Companybook-Crawler \(\+https://www.companybooknetworking.com/\)
+## should be blocked by generic crawler rule
+# exclude Companybook-Crawler \(\+https://www.companybooknetworking.com/\)
 exclude DuckDuckBot/.*; \(\+http://duckduckgo.com/duckduckbot.html\)
-exclude GarlikCrawler/.* \(http://garlik.com/, crawler@garlik.com\)
+## should be blocked by generic crawler rule
+# exclude GarlikCrawler/.* \(http://garlik.com/, crawler@garlik.com\)
 exclude .* AhrefsBot/.*; \+http://ahrefs.com/robot/\)
-exclude Mozilla/5.0 \(Macintosh; Intel Mac OS X.*\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Safari/.* \(Applebot/.*; \+http://www.apple.com/go/applebot
+## this didn't work to block the apple bot, potentially added correctly in a different PR - missing end paren
+# exclude Mozilla/5.0 \(Macintosh; Intel Mac OS X.*\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Safari/.* \(Applebot/.*; \+http://www.apple.com/go/applebot
 exclude Mozilla/5.0 \(compatible; Daum/.*; \+http://cs.daum.net/faq/15/4118.html?faqId=28966\)
 exclude Mozilla/5.0 \(compatible; SEOkicks; \+https://www.seokicks.de/robot.html\)
-exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\)
+## this didn't work to block the Yandex bot, potentially fixed in a different PR - account for suffixes
+# exclude Mozilla/5.0 \(compatible; YandexBot/.*; \+http://yandex.com/bots\)
 exclude Linguee Bot \(\+http://www.linguee.com/bot; bot@linguee.com\)
 exclude .* BLEXBot/.*; \+http://webmeup-crawler.com/\)
 exclude .* Baiduspider/.*; \+http://www.baidu.com/search/spider.html\)
 exclude .* [Bb]ingbot/.*; \+http://www.bing.com/bingbot.html?\)
-exclude Mozilla/5.0 \(iPhone; CPU iPhone OS.* like Mac OS X\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Mobile/.* Safari/.* \(compatible; bingbot/.*; \+http://www.bing.com/bingbot.htm\)
+## should be covered by above bingbot rule
+# exclude Mozilla/5.0 \(iPhone; CPU iPhone OS.* like Mac OS X\) AppleWebKit/.* \(KHTML, like Gecko\) Version/.* Mobile/.* Safari/.* \(compatible; bingbot/.*; \+http://www.bing.com/bingbot.htm\)
 exclude .* DotBot/.*; http://www.opensiteexplorer.org/dotbot, help@moz.com\)
 exclude .* Exabot/.*; \+http://www.exabot.com/go/robot\)
 exclude .* Googlebot/.*; \+http://www.google.com/bot.html\)
 exclude .* Konqueror/.*; Linux\) KHTML/.* \(like Gecko\) \(Exabot-Thumbnails\)
 exclude .* MJ12bot/.*; http://mj12bot.com/\)
 exclude .* MSIE .*; Windows NT .*; Trident/.*\) LinkCheck by Siteimprove.com
-exclude .* MegaIndex.ru/.*; \+http://megaindex.com/crawler\)
+## should be covered by generic crawler rule
+# exclude .* MegaIndex.ru/.*; \+http://megaindex.com/crawler\)
 exclude .* SemrushBot/.*\~bl; \+http://www.semrush.com/bot.html\)
 exclude .* Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp\)
 exclude .* linkdexbot/.*; \+http://www.linkdex.com/bots/\)
 exclude .* Yandex\(Mobile\)?Bot/.*; \+http://yandex.com/bots\)
-exclude Mozilla/5.0 \(compatible; SiteExplorer/.*; \+http://siteexplorer.info/Backlink-Checker-Spider/\)
+## should be covered by generic spider rule
+# exclude Mozilla/5.0 \(compatible; SiteExplorer/.*; \+http://siteexplorer.info/Backlink-Checker-Spider/\)
 exclude Apache-HttpClient/.* \(Java/.*\)
 exclude Python/.* aiohttp/.*
 exclude panscient.com 
-exclude Sogou Orion spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou Pic Spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou head spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou web spider/.* \(\+http://www.sogou.com/docs/help/webmasters.htm#07\)
-exclude Sogou-Test-Spider/.* \(compatible; MSIE .*; Windows 98\)
-exclude TurnitinBot \(https://turnitin.com/robot/crawlerinfo.html\)
-exclude erdc-gsadev-crawler \(Enterprise; T4-CAJN8GR8VSNFA; christopher.a.boler@erdc.dren.mil\)
+## these should all be blocked by the generic spider rule
+# exclude Sogou Orion spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
+# exclude Sogou Pic Spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
+# exclude Sogou head spider/.* \(http://www.sogou.com/docs/help/webmasters.htm#07\)
+# exclude Sogou web spider/.* \(\+http://www.sogou.com/docs/help/webmasters.htm#07\)
+# exclude Sogou-Test-Spider/.* \(compatible; MSIE .*; Windows 98\)
+## should be blocked by generic crawler rule
+# exclude TurnitinBot \(https://turnitin.com/robot/crawlerinfo.html\)
+## this should be blocked by the generic crawler rule
+# exclude erdc-gsadev-crawler \(Enterprise; T4-CAJN8GR8VSNFA; christopher.a.boler@erdc.dren.mil\)
 exclude facebookexternalhit/.* \(\+http://www.facebook.com/externalhit_uatext.php\)
-exclude facebot
-exclude ia_archiver \(\+http://www.alexa.com/site/help/webmasters; crawler@alexa.com\)
+## this may no longer be in use by Facebook but should have been capitalized
+# exclude facebot
+## no longer used by alexa?
+# exclude ia_archiver \(\+http://www.alexa.com/site/help/webmasters; crawler@alexa.com\)
+## moved from bottom to proximity to existing rule
+exclude ia_archiver
 exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
 exclude Twitterbot/.*
 exclude SocialRankIOBot; http://socialrank.io/about
-exclude CCBot/.*http://commoncrawl.org/about/
+## already defined above
+# exclude CCBot/.*http://commoncrawl.org/about/
 exclude ltx71.*\(http://ltx71.com/\)
 exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
 exclude Zepheira QA/.*
-exclude canonical
-exclude embedded
+## these two suspiciously match unrelated parts of the logs and are almost certainly not user agent strings
+# exclude canonical
+# exclude embedded
 exclude Blackboard Safeassign
-exclude ia_archiver

--- a/useragents.dat
+++ b/useragents.dat
@@ -11,8 +11,8 @@ exclude .* Mail.RU_Bot/.*; \+http://go.mail.ru/help/robots\)
 ## should be blocked by the generic spider rule
 # exclude YisouSpider
 exclude MauiBot \(crawler.feedback\+wc@gmail.com\)
-exclude CCBot/.* \(https?://commoncrawl.org/faq/\)
-## regex above now covers both of these cases
+## out of date, see below
+# exclude CCBot/.* \(https://commoncrawl.org/faq/\)
 # exclude CCBot/.* \(http://commoncrawl.org/faq/\)
 exclude .* Qwantify/.*; \+https://www.qwant.com/\)/.*
 ## should be blocked by generic crawler rule
@@ -70,8 +70,7 @@ exclude ia_archiver
 exclude Slackbot-LinkExpanding .* \(\+https://api.slack.com/robots\)
 exclude Twitterbot/.*
 exclude SocialRankIOBot; http://socialrank.io/about
-## already defined above
-# exclude CCBot/.*http://commoncrawl.org/about/
+exclude CCBot/.*http://commoncrawl.org/about/
 exclude ltx71.*\(http://ltx71.com/\)
 exclude PiplBot.*\(\+http://www.pipl.com/bot/\)
 exclude Zepheira QA/.*


### PR DESCRIPTION
There are some problematic lines in here.  Some did not match their intended targets due to incomplete regex syntax that would miss leading or trailing strings, some are repeats, and others look out of place.  I think I'm going to add a flag and bits to tally how many times each pattern was matched with debug on the user agent that matched, along with a report on all user agents that made it past.

Up for discussion, not merging right away.  In the end, suspect lines should be removed.